### PR TITLE
Add variable to set log group name if you want to override the default

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -105,7 +105,7 @@ resource "aws_lambda_alias" "this" {
 }
 
 resource "aws_cloudwatch_log_group" "this" {
-  name              = "/aws/lambda/${aws_lambda_function.this.function_name}"
+  name              = var.log_group_name != null ? "/aws/lambda/${var.log_group_name}" : "/aws/lambda/${aws_lambda_function.this.function_name}"
   retention_in_days = var.log_retention_in_days
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -158,3 +158,9 @@ variable "enable_insights" {
   type        = bool
   default     = false
 }
+
+variable "log_group_name" {
+  description = "Override default log group name, if not set a default name will be used from the lambda function name"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
Make it easier to migrate into the module from existing lambda modules without manually importing or deleting while running the pipelines.