### PR TITLE
Fix custom log group name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 locals {
-  function_name = var.component_name != null ? "${var.service_name}-${var.component_name}" : var.service_name
+  function_name  = var.component_name != null ? "${var.service_name}-${var.component_name}" : var.service_name
+  log_group_name = var.log_group_name != null ? "/aws/lambda/${var.log_group_name}" : "/aws/lambda/${local.function_name}"
 }
 
 data "aws_iam_policy_document" "assume_role_policy" {
@@ -69,6 +70,11 @@ resource "aws_lambda_function" "this" {
     security_group_ids = var.security_group_ids
   }
 
+  logging_config {
+    log_format = "Text"
+    log_group  = local.log_group_name
+  }
+
   environment {
     variables = var.enable_datadog ? merge(var.environment_variables, local.environment_variables.common, local.environment_variables.runtime) : var.environment_variables
   }
@@ -112,7 +118,7 @@ resource "aws_lambda_alias" "this" {
 }
 
 resource "aws_cloudwatch_log_group" "this" {
-  name              = var.log_group_name != null ? "/aws/lambda/${var.log_group_name}" : "/aws/lambda/${aws_lambda_function.this.function_name}"
+  name              = local.log_group_name
   retention_in_days = var.log_retention_in_days
 }
 

--- a/main.tf
+++ b/main.tf
@@ -71,7 +71,7 @@ resource "aws_lambda_function" "this" {
   }
 
   logging_config {
-    log_format = "Text"
+    log_format = var.log_format
     log_group  = local.log_group_name
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -172,6 +172,17 @@ variable "log_group_name" {
   default     = null
 }
 
+variable "log_format" {
+  description = "The format of the logs. Can be either `Text` or `JSON`. Defaults to `Text`."
+  type        = string
+  default     = "Text"
+
+  validation {
+    condition     = contains(["Text", "JSON"], var.log_format)
+    error_message = "Log format must be one of `Text` or `JSON`."
+  }
+}
+
 # DATADOG
 variable "enable_datadog" {
   description = "Enable Datadog Lambda Extension"


### PR DESCRIPTION
Fikser bruk av custom log group ved å konfigurere lambdaen til å bruke den oppgitte gruppen og ikke bare at den blir opprettet